### PR TITLE
fix: Fixed behavior of json decoders to return DecodingFailure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,8 +31,8 @@ repositories {
 
 dependencies {
     compile "org.scala-lang:scala-library:${scalaLibraryVersion}"
+    compile "io.circe:circe-core_${scalaVersion}:0.11.2"
     compileOnly "org.json4s:json4s-core_${scalaVersion}:3.6.7"
-    compileOnly "io.circe:circe-core_${scalaVersion}:0.11.2"
 
     testCompile "org.scalatest:scalatest_${scalaVersion}:3.0.8"
     testCompile "junit:junit:4.12"

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ targetCompatibility = '1.8'
 ext {
     scalaVersion = '2.12'
     scalaLibraryVersion = '2.12.10'
+    circeVersion = '0.11.2'
 }
 
 group = 'com.avast.hashes'
@@ -31,10 +32,11 @@ repositories {
 
 dependencies {
     compile "org.scala-lang:scala-library:${scalaLibraryVersion}"
-    compile "io.circe:circe-core_${scalaVersion}:0.11.2"
     compileOnly "org.json4s:json4s-core_${scalaVersion}:3.6.7"
+    compileOnly "io.circe:circe-core_${scalaVersion}:${circeVersion}"
 
     testCompile "org.scalatest:scalatest_${scalaVersion}:3.0.8"
+    testCompile "io.circe:circe-core_${scalaVersion}:${circeVersion}"
     testCompile "junit:junit:4.12"
 }
 

--- a/src/main/scala/com/avast/scala/hashes/circe/package.scala
+++ b/src/main/scala/com/avast/scala/hashes/circe/package.scala
@@ -1,12 +1,31 @@
 package com.avast.scala.hashes
 
-import io.circe.{Decoder, Encoder}
+import io.circe._
+
+import scala.reflect.ClassTag
+import scala.util.control.NonFatal
 
 package object circe {
-  implicit val Sha256Decoder = Decoder.decodeString.map(Sha256(_))
-  implicit val Sha256Encoder = Encoder.encodeString.contramap((s: Sha256) => s.toString)
-  implicit val MD5Decoder = Decoder.decodeString.map(MD5(_))
-  implicit val MD5Encoder = Encoder.encodeString.contramap((h: MD5) => h.toString)
-  implicit val Sha1Decoder = Decoder.decodeString.map(Sha1(_))
-  implicit val Sha1Encoder = Encoder.encodeString.contramap((s: Sha1) => s.toString)
+  implicit val Sha256Decoder: Decoder[Sha256] = prepareDecoder(Sha256(_))
+  implicit val Sha256Encoder: Encoder[Sha256] = Encoder.encodeString.contramap((s: Sha256) => s.toString)
+  implicit val MD5Decoder: Decoder[MD5] = prepareDecoder(MD5(_))
+  implicit val MD5Encoder: Encoder[MD5] = Encoder.encodeString.contramap((h: MD5) => h.toString)
+  implicit val Sha1Decoder: Decoder[Sha1] = prepareDecoder(Sha1(_))
+  implicit val Sha1Encoder: Encoder[Sha1] = Encoder.encodeString.contramap((s: Sha1) => s.toString)
+
+  private def prepareDecoder[A: ClassTag](parse: String => A): Decoder[A] =
+    (c: HCursor) => {
+      c.value.as[String].flatMap { s =>
+        try {
+          Right(parse(s))
+        } catch {
+          case NonFatal(_) =>
+            Left {
+              DecodingFailure(
+                implicitly[ClassTag[A]].runtimeClass.getSimpleName,
+                c.history)
+            }
+        }
+      }
+    }
 }

--- a/src/test/scala/com/avast/scala/hashes/circe/MD5Sha1Decoder.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/MD5Sha1Decoder.scala
@@ -1,0 +1,27 @@
+package com.avast.scala.hashes.circe
+
+import com.avast.scala.hashes.MD5
+import io.circe.{DecodingFailure, Json}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class MD5Sha1Decoder extends FlatSpec with Matchers {
+  "it" should "deserialize valid MD5" in {
+    val value = MD5("6a18b3c45107538de9d430f83a6af988")
+
+    val result = MD5Decoder.decodeJson(Json.fromString(value.toString))
+
+    assertResult(Right(value))(result)
+  }
+
+  "deserialization" should "correctly fail in case of invalid MD5" in {
+    val result = MD5Decoder.decodeJson(Json.fromString("InvalidValue"))
+
+    result match {
+      case Left(_: DecodingFailure) => succeed
+      case _ => fail()
+    }
+  }
+}

--- a/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
@@ -1,0 +1,27 @@
+package com.avast.scala.hashes.circe
+
+import com.avast.scala.hashes.{Sha1, Sha256}
+import io.circe.{DecodingFailure, Json}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class Sha1DecoderTest extends FlatSpec with Matchers {
+  "it" should "deserialize valid Sha1" in {
+    val value = Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3")
+
+    val result = Sha1Decoder.decodeJson(Json.fromString(value.toString))
+
+    assertResult(Right(value))(result)
+  }
+
+  "deserialization" should "correctly fail in case of invalid Sha1" in {
+    val result = Sha1Decoder.decodeJson(Json.fromString("InvalidValue"))
+
+    result match {
+      case Left(_: DecodingFailure) => succeed
+      case _ => fail()
+    }
+  }
+}

--- a/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
@@ -1,6 +1,6 @@
 package com.avast.scala.hashes.circe
 
-import com.avast.scala.hashes.{Sha1, Sha256}
+import com.avast.scala.hashes.Sha1
 import io.circe.{DecodingFailure, Json}
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/src/test/scala/com/avast/scala/hashes/circe/Sha256DecoderTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/Sha256DecoderTest.scala
@@ -1,0 +1,27 @@
+package com.avast.scala.hashes.circe
+
+import com.avast.scala.hashes.Sha256
+import io.circe.{DecodingFailure, Json}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{FlatSpec, Matchers}
+
+@RunWith(classOf[JUnitRunner])
+class Sha256DecoderTest extends FlatSpec with Matchers {
+  "it" should "deserialize valid SHA256" in {
+    val value = Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446")
+
+    val result = Sha256Decoder.decodeJson(Json.fromString(value.toString))
+
+    assertResult(Right(value))(result)
+  }
+
+  "deserialization" should "correctly fail in case of invalid Sha256" in {
+    val result = Sha256Decoder.decodeJson(Json.fromString("InvalidValue"))
+
+    result match {
+      case Left(_: DecodingFailure) => succeed
+      case _ => fail()
+    }
+  }
+}


### PR DESCRIPTION
Fixed behavior of json decoders to return DecodingFailure and not throw exception in case of failure.

Current implementation either returns Right(value) or throws exception, which is not correct implementation of io.circe.Decoder.