### PR TITLE
base64 parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,8 @@ dependencies {
     compileOnly "org.json4s:json4s-core_${scalaVersion}:3.6.7"
     compileOnly "io.circe:circe-core_${scalaVersion}:${circeVersion}"
 
-    testCompile "org.scalatest:scalatest_${scalaVersion}:3.0.8"
+    testCompile "org.scalatest:scalatest_${scalaVersion}:3.2.0"
+    testCompile "org.scalatestplus:junit-4-12_${scalaVersion}:3.1.3.0"
     testCompile "io.circe:circe-core_${scalaVersion}:${circeVersion}"
     testCompile "junit:junit:4.13"
 }

--- a/src/main/scala/com/avast/scala/hashes/MD5.scala
+++ b/src/main/scala/com/avast/scala/hashes/MD5.scala
@@ -6,6 +6,7 @@ case class MD5(bytes: Array[Byte]) {
   require(bytes.length == 16, s"Invalid MD5: ${MD5.bytesLength} bytes expected but ${bytes.length} provided")
 
   final def toBase64String: String = bytes2base64(bytes)
+  final def toHexString: String = bytes2hex(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)

--- a/src/main/scala/com/avast/scala/hashes/MD5.scala
+++ b/src/main/scala/com/avast/scala/hashes/MD5.scala
@@ -3,7 +3,9 @@ package com.avast.scala.hashes
 import java.util
 
 case class MD5(bytes: Array[Byte]) {
-  require(bytes.length == 16, s"Invalid MD5: 16 bytes expected but ${bytes.length} provided")
+  require(bytes.length == 16, s"Invalid MD5: ${MD5.bytesLength} bytes expected but ${bytes.length} provided")
+
+  final def toBase64String: String = bytes2base64(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)
@@ -14,5 +16,6 @@ case class MD5(bytes: Array[Byte]) {
 }
 
 object MD5 {
-  def apply(hex: String): MD5 = MD5(hex2bytes(hex))
+  private val bytesLength = 16
+  def apply(hexOrBase64: String): MD5 = MD5(if (hexOrBase64.length == 2 * bytesLength) hex2bytes(hexOrBase64) else base642bytes(hexOrBase64))
 }

--- a/src/main/scala/com/avast/scala/hashes/Sha1.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha1.scala
@@ -6,6 +6,7 @@ case class Sha1(bytes: Array[Byte]) {
   require(bytes.length == 20, s"Invalid Sha1: ${Sha1.bytesLength} bytes expected but ${bytes.length} provided")
 
   final def toBase64String: String = bytes2base64(bytes)
+  final def toHexString: String = bytes2hex(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)

--- a/src/main/scala/com/avast/scala/hashes/Sha1.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha1.scala
@@ -3,7 +3,9 @@ package com.avast.scala.hashes
 import java.util
 
 case class Sha1(bytes: Array[Byte]) {
-  require(bytes.length == 20, s"Invalid Sha1: 20 bytes expected but ${bytes.length} provided")
+  require(bytes.length == 20, s"Invalid Sha1: ${Sha1.bytesLength} bytes expected but ${bytes.length} provided")
+
+  final def toBase64String: String = bytes2base64(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)
@@ -14,5 +16,6 @@ case class Sha1(bytes: Array[Byte]) {
 }
 
 object Sha1 {
-  def apply(hex: String): Sha1 = Sha1(hex2bytes(hex))
+  private val bytesLength = 20
+  def apply(hexOrBase64: String): Sha1 = Sha1(if (hexOrBase64.length == 2 * bytesLength) hex2bytes(hexOrBase64) else base642bytes(hexOrBase64))
 }

--- a/src/main/scala/com/avast/scala/hashes/Sha256.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha256.scala
@@ -6,6 +6,7 @@ case class Sha256(bytes: Array[Byte]) {
   require(bytes.length == 32, s"Invalid Sha256: ${Sha256.bytesLength} bytes expected but ${bytes.length} provided")
 
   final def toBase64String: String = bytes2base64(bytes)
+  final def toHexString: String = bytes2hex(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)

--- a/src/main/scala/com/avast/scala/hashes/Sha256.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha256.scala
@@ -3,7 +3,9 @@ package com.avast.scala.hashes
 import java.util
 
 case class Sha256(bytes: Array[Byte]) {
-  require(bytes.length == 32, s"Invalid Sha256: 32 bytes expected but ${bytes.length} provided")
+  require(bytes.length == 32, s"Invalid Sha256: ${Sha256.bytesLength} bytes expected but ${bytes.length} provided")
+
+  final def toBase64String: String = bytes2base64(bytes)
 
   override def toString: String = bytes2hex(bytes)
   override def hashCode(): Int = util.Arrays.hashCode(bytes)
@@ -14,5 +16,6 @@ case class Sha256(bytes: Array[Byte]) {
 }
 
 object Sha256 {
-  def apply(hex: String): Sha256 = Sha256(hex2bytes(hex))
+  private val bytesLength = 32
+  def apply(hexOrBase64: String): Sha256 = Sha256(if (hexOrBase64.length == 2 * bytesLength) hex2bytes(hexOrBase64) else base642bytes(hexOrBase64))
 }

--- a/src/main/scala/com/avast/scala/hashes/package.scala
+++ b/src/main/scala/com/avast/scala/hashes/package.scala
@@ -1,5 +1,7 @@
 package com.avast.scala
 
+import java.util.Base64
+
 package object hashes {
   def hex2bytes(hex: String): Array[Byte] = hex.replaceAll("[^0-9A-Fa-f]", "").sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
 
@@ -8,4 +10,8 @@ package object hashes {
       case None => bytes.map("%02x".format(_)).mkString
       case _ => bytes.map("%02x".format(_)).mkString(sep.get)
     }
+
+  def base642bytes(base64: String): Array[Byte] = Base64.getDecoder.decode(base64)
+
+  def bytes2base64(bytes: Array[Byte]): String = Base64.getEncoder.encodeToString(bytes)
 }

--- a/src/test/scala/com/avast/scala/hashes/HashesMotherTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/HashesMotherTest.scala
@@ -1,11 +1,12 @@
 package com.avast.scala.hashes
 
 import org.junit.runner.RunWith
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class HashesMotherTest extends FlatSpec with Matchers {
+class HashesMotherTest extends AnyFlatSpec with Matchers {
   it should "generate random sha256" in {
     val first = HashesMother.randomSha256()
     val second = HashesMother.randomSha256()

--- a/src/test/scala/com/avast/scala/hashes/MD5Test.scala
+++ b/src/test/scala/com/avast/scala/hashes/MD5Test.scala
@@ -1,20 +1,21 @@
 package com.avast.scala.hashes
 
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class MD5Test extends FlatSpec with Matchers {
-  "it" should "include the underlying bytes in equality comparison" in {
+class MD5Test extends AnyFlatSpec with Matchers {
+  it should "include the underlying bytes in equality comparison" in {
     MD5("6a18b3c45107538de9d430f83a6af988") shouldBe MD5("6a18b3c45107538de9d430f83a6aF988")
   }
 
-  "it" should "include the underlying bytes in hashcode computation" in {
+  it should "include the underlying bytes in hashcode computation" in {
     MD5("6a18b3c45107538de9d430f83a6af988").hashCode() shouldBe MD5("6a18b3c45107538de9d430f83a6af988").hashCode()
   }
 
-  "it" should "convert MD5 to lower-case" in {
+  it should "convert MD5 to lower-case" in {
     MD5("6A18B3C45107538DE9D430F83A6AF988").toString() shouldBe "6a18b3c45107538de9d430f83a6af988"
   }
 }

--- a/src/test/scala/com/avast/scala/hashes/Sha1Test.scala
+++ b/src/test/scala/com/avast/scala/hashes/Sha1Test.scala
@@ -1,20 +1,21 @@
 package com.avast.scala.hashes
 
 import org.junit.runner.RunWith
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class Sha1Test extends FlatSpec with Matchers {
-  "it" should "include the underlying bytes in equality comparison" in {
+class Sha1Test extends AnyFlatSpec with Matchers {
+  it should "include the underlying bytes in equality comparison" in {
     Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3") shouldBe Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3")
   }
 
-  "it" should "include the underlying bytes in hashcode computation" in {
+  it should "include the underlying bytes in hashcode computation" in {
     Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3").hashCode() shouldBe Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3").hashCode()
   }
 
-  "it" should "convert the Sha1 to lower-case string" in {
+  it should "convert the Sha1 to lower-case string" in {
     Sha1("0FD08A268F6032CE2A83A17AC8ADCEAF82ADE5E3").toString() shouldBe "0fd08a268f6032ce2a83a17ac8adceaf82ade5e3"
   }
 }

--- a/src/test/scala/com/avast/scala/hashes/Sha256Test.scala
+++ b/src/test/scala/com/avast/scala/hashes/Sha256Test.scala
@@ -18,4 +18,8 @@ class Sha256Test extends AnyFlatSpec with Matchers {
   it should "convert the Sha256 to lower-case string" in {
     Sha256("6A18B3C45107538DE9D430F83A6AF988EDBDDEB4E5A6BDB16F223A2FA37EE446").toString() shouldBe "6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446"
   }
+
+  it should "generate base64 of the same length for random SHA256" in {
+     (1 to 32).map(_ => Sha256(HashesMother.randomHexString(64)).toBase64String.length) shouldBe (1 to 32).map(_ => 44)
+  }
 }

--- a/src/test/scala/com/avast/scala/hashes/Sha256Test.scala
+++ b/src/test/scala/com/avast/scala/hashes/Sha256Test.scala
@@ -1,20 +1,21 @@
 package com.avast.scala.hashes
 
 import org.junit.runner.RunWith
-import org.scalatest.{FlatSpec, Matchers}
-import org.scalatest.junit.JUnitRunner
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class Sha256Test extends FlatSpec with Matchers {
-  "it" should "include the underlying bytes in equality comparison" in {
+class Sha256Test extends AnyFlatSpec with Matchers {
+  it should "include the underlying bytes in equality comparison" in {
     Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446") shouldBe Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446")
   }
 
-  "it" should "include the underlying bytes in hashcode computation" in {
+  it should "include the underlying bytes in hashcode computation" in {
     Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446").hashCode() shouldBe Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446").hashCode()
   }
 
-  "it" should "convert the Sha256 to lower-case string" in {
+  it should "convert the Sha256 to lower-case string" in {
     Sha256("6A18B3C45107538DE9D430F83A6AF988EDBDDEB4E5A6BDB16F223A2FA37EE446").toString() shouldBe "6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446"
   }
 }

--- a/src/test/scala/com/avast/scala/hashes/circe/MD5Sha1Decoder.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/MD5Sha1Decoder.scala
@@ -3,12 +3,13 @@ package com.avast.scala.hashes.circe
 import com.avast.scala.hashes.MD5
 import io.circe.{DecodingFailure, Json}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class MD5Sha1Decoder extends FlatSpec with Matchers {
-  "it" should "deserialize valid MD5" in {
+class MD5Sha1Decoder extends AnyFlatSpec with Matchers {
+  it should "deserialize valid MD5" in {
     val value = MD5("6a18b3c45107538de9d430f83a6af988")
 
     val result = MD5Decoder.decodeJson(Json.fromString(value.toString))

--- a/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/Sha1DecoderTest.scala
@@ -3,12 +3,13 @@ package com.avast.scala.hashes.circe
 import com.avast.scala.hashes.Sha1
 import io.circe.{DecodingFailure, Json}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class Sha1DecoderTest extends FlatSpec with Matchers {
-  "it" should "deserialize valid Sha1" in {
+class Sha1DecoderTest extends AnyFlatSpec with Matchers {
+  it should "deserialize valid Sha1" in {
     val value = Sha1("0fd08a268f6032ce2a83a17ac8adceaf82ade5e3")
 
     val result = Sha1Decoder.decodeJson(Json.fromString(value.toString))

--- a/src/test/scala/com/avast/scala/hashes/circe/Sha256DecoderTest.scala
+++ b/src/test/scala/com/avast/scala/hashes/circe/Sha256DecoderTest.scala
@@ -3,12 +3,13 @@ package com.avast.scala.hashes.circe
 import com.avast.scala.hashes.Sha256
 import io.circe.{DecodingFailure, Json}
 import org.junit.runner.RunWith
-import org.scalatest.junit.JUnitRunner
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
 
 @RunWith(classOf[JUnitRunner])
-class Sha256DecoderTest extends FlatSpec with Matchers {
-  "it" should "deserialize valid SHA256" in {
+class Sha256DecoderTest extends AnyFlatSpec with Matchers {
+  it should "deserialize valid SHA256" in {
     val value = Sha256("6a18b3c45107538de9d430f83a6af988edbddeb4e5a6bdb16f223a2fa37ee446")
 
     val result = Sha256Decoder.decodeJson(Json.fromString(value.toString))


### PR DESCRIPTION
This PR doesn't break API nor contract compatibility. Is just allows to parse also from base64 representation, and allows to serialize to base64. So I would like to publish a new minor version after this PR will be merged.

Then I will prepare another PR that will change the json4s and circe implementation to use `toBase64String` instead of `toString` for encoding.

In our applications, we firstly update to the next minor version (this ensures we will be able to parse also base64) and later to the new major version.