### PR TITLE
Move Circe instances to companion objects

### DIFF
--- a/src/main/scala/com/avast/scala/hashes/MD5.scala
+++ b/src/main/scala/com/avast/scala/hashes/MD5.scala
@@ -1,5 +1,7 @@
 package com.avast.scala.hashes
 
+import io.circe.{Decoder, Encoder}
+
 import java.util
 
 case class MD5(bytes: Array[Byte]) {
@@ -19,4 +21,7 @@ case class MD5(bytes: Array[Byte]) {
 object MD5 {
   private val bytesLength = 16
   def apply(hexOrBase64: String): MD5 = MD5(tryHex2bytes(hexOrBase64, bytesLength).getOrElse(base642bytes(hexOrBase64)))
+
+  implicit lazy val MD5Decoder: Decoder[MD5] = circe.prepareDecoder(MD5(_))
+  implicit lazy val MD5Encoder: Encoder[MD5] = Encoder.encodeString.contramap((h: MD5) => h.toString)
 }

--- a/src/main/scala/com/avast/scala/hashes/Sha1.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha1.scala
@@ -1,5 +1,7 @@
 package com.avast.scala.hashes
 
+import io.circe.{Decoder, Encoder}
+
 import java.util
 
 case class Sha1(bytes: Array[Byte]) {
@@ -19,4 +21,7 @@ case class Sha1(bytes: Array[Byte]) {
 object Sha1 {
   private val bytesLength = 20
   def apply(hexOrBase64: String): Sha1 = Sha1(tryHex2bytes(hexOrBase64, bytesLength).getOrElse(base642bytes(hexOrBase64)))
+
+  implicit lazy val Sha1Decoder: Decoder[Sha1] = circe.prepareDecoder(Sha1(_))
+  implicit lazy val Sha1Encoder: Encoder[Sha1] = Encoder.encodeString.contramap((s: Sha1) => s.toString)
 }

--- a/src/main/scala/com/avast/scala/hashes/Sha256.scala
+++ b/src/main/scala/com/avast/scala/hashes/Sha256.scala
@@ -1,5 +1,7 @@
 package com.avast.scala.hashes
 
+import io.circe.{Decoder, Encoder}
+
 import java.util
 
 case class Sha256(bytes: Array[Byte]) {
@@ -19,4 +21,7 @@ case class Sha256(bytes: Array[Byte]) {
 object Sha256 {
   private val bytesLength = 32
   def apply(hexOrBase64: String): Sha256 = Sha256(tryHex2bytes(hexOrBase64, bytesLength).getOrElse(base642bytes(hexOrBase64)))
+
+  implicit lazy val Sha256Decoder: Decoder[Sha256] = circe.prepareDecoder(Sha256(_))
+  implicit lazy val Sha256Encoder: Encoder[Sha256] = Encoder.encodeString.contramap((s: Sha256) => s.toString)
 }

--- a/src/main/scala/com/avast/scala/hashes/circe/package.scala
+++ b/src/main/scala/com/avast/scala/hashes/circe/package.scala
@@ -4,14 +4,15 @@ import cats.syntax.all._
 import io.circe._
 
 package object circe {
-  implicit val Sha256Decoder: Decoder[Sha256] = prepareDecoder(Sha256(_))
-  implicit val Sha256Encoder: Encoder[Sha256] = Encoder.encodeString.contramap((s: Sha256) => s.toString)
-  implicit val MD5Decoder: Decoder[MD5] = prepareDecoder(MD5(_))
-  implicit val MD5Encoder: Encoder[MD5] = Encoder.encodeString.contramap((h: MD5) => h.toString)
-  implicit val Sha1Decoder: Decoder[Sha1] = prepareDecoder(Sha1(_))
-  implicit val Sha1Encoder: Encoder[Sha1] = Encoder.encodeString.contramap((s: Sha1) => s.toString)
+  // links here to stay backwards compatible, but users should use de-/en-coders from the companion objects, i.e. out of the box without imports
+  implicit lazy val Sha256Decoder: Decoder[Sha256] = Sha256.Sha256Decoder
+  implicit lazy val Sha256Encoder: Encoder[Sha256] = Sha256.Sha256Encoder
+  implicit lazy val MD5Decoder: Decoder[MD5] = MD5.MD5Decoder
+  implicit lazy val MD5Encoder: Encoder[MD5] = MD5.MD5Encoder
+  implicit lazy val Sha1Decoder: Decoder[Sha1] = Sha1.Sha1Decoder
+  implicit lazy val Sha1Encoder: Encoder[Sha1] = Sha1.Sha1Encoder
 
-  private def prepareDecoder[A](parse: String => A): Decoder[A] =
+  private[hashes] def prepareDecoder[A](parse: String => A): Decoder[A] =
     (c: HCursor) => {
       c.value.as[String].flatMap { s =>
         Either


### PR DESCRIPTION
When type class implementations are in the companion object, they work out of the box. Having them anywhere else causes unnecessary friction.

Read more on the topic here https://meta.plasm.us/posts/2019/09/30/implicit-scope-and-cats/