### PR TITLE
feat: parsing and printing optimized

### DIFF
--- a/core/src/main/scala/com/avast/scala/hashes/package.scala
+++ b/core/src/main/scala/com/avast/scala/hashes/package.scala
@@ -7,6 +7,10 @@ package object hashes {
 
   private val hexAllowedCharactersRegex = Pattern.compile("[^0-9A-Fa-f]")
 
+  /**
+   * Removes all the non-HEX characters from the input string and then transform the remaining HEX characters to byte array.
+   * So this method never throws an exception.
+   */
   def hex2bytes(hex: String): Array[Byte] = hex2bytesUnchecked(hexAllowedCharactersRegex.matcher(hex).replaceAll(""))
 
   private def hex2bytesUnchecked(hex: String): Array[Byte] = {
@@ -19,19 +23,25 @@ package object hashes {
     r
   }
 
-  def hexCharToInt(c: Character): Int = c match {
+  private def hexCharToInt(c: Character): Int = c match {
     case c if c >= '0' && c <= '9' => c - '0'
     case c if c >= 'a' && c <= 'f' => 10 + (c - 'a')
     case c if c >= 'A' && c <= 'F' => 10 + (c - 'A')
     case _                         => throw new IllegalArgumentException
   }
 
+  /**
+   * Removes all the non-HEX characters from the input string and then performs the check if the remaining characters
+   * could be decoded to expected bytes. If so, decodes them, returns None otherwise.
+   */
   def tryHex2bytes(maybeHex: String, expectedBytes: Int): Option[Array[Byte]] = {
     val clean = hexAllowedCharactersRegex.matcher(maybeHex).replaceAll("")
     if (clean.length == 2 * expectedBytes) Some(hex2bytesUnchecked(clean)) else None
   }
 
-
+  /**
+   * Encodes bytes to lower-case HEX string, optionally with a separator between bytes (so between every two characters).
+   */
   def bytes2hex(bytes: Array[Byte], sep: Option[String] = None): String =
     sep match {
       case None =>

--- a/core/src/main/scala/com/avast/scala/hashes/package.scala
+++ b/core/src/main/scala/com/avast/scala/hashes/package.scala
@@ -6,18 +6,52 @@ import java.util.regex.Pattern
 package object hashes {
 
   private val hexAllowedCharactersRegex = Pattern.compile("[^0-9A-Fa-f]")
-  def hex2bytes(hex: String): Array[Byte] = hexbytesUnchecked(hexAllowedCharactersRegex.matcher(hex).replaceAll(""))
-  private def hexbytesUnchecked(hex: String): Array[Byte] = hex.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toByte)
+
+  def hex2bytes(hex: String): Array[Byte] = hex2bytesUnchecked(hexAllowedCharactersRegex.matcher(hex).replaceAll(""))
+
+  private def hex2bytesUnchecked(hex: String): Array[Byte] = {
+    val r = new Array[Byte](hex.length / 2)
+    var i = 0
+    while (i < (hex.length / 2)) {
+      r(i) = ((hexCharToInt(hex(i*2)) << 4) | hexCharToInt(hex(i*2+1))).toByte
+      i += 1
+    }
+    r
+  }
+
+  def hexCharToInt(c: Character): Int = c match {
+    case c if c >= '0' && c <= '9' => c - '0'
+    case c if c >= 'a' && c <= 'f' => 10 + (c - 'a')
+    case c if c >= 'A' && c <= 'F' => 10 + (c - 'A')
+    case _                         => throw new IllegalArgumentException
+  }
+
   def tryHex2bytes(maybeHex: String, expectedBytes: Int): Option[Array[Byte]] = {
     val clean = hexAllowedCharactersRegex.matcher(maybeHex).replaceAll("")
-    if (clean.length == 2 * expectedBytes) Some(hexbytesUnchecked(clean)) else None
+    if (clean.length == 2 * expectedBytes) Some(hex2bytesUnchecked(clean)) else None
   }
+
 
   def bytes2hex(bytes: Array[Byte], sep: Option[String] = None): String =
     sep match {
-      case None => bytes.map("%02x".format(_)).mkString
-      case _ => bytes.map("%02x".format(_)).mkString(sep.get)
+      case None =>
+        val sb = new StringBuilder(bytes.length * 2)
+        bytes.foreach(byteToHexChars(_, sb))
+        sb.toString()
+      case Some(s) =>
+        val sb = new StringBuilder(bytes.length * (2 + s.length))
+        bytes.foreach { b =>
+          byteToHexChars(b, sb)
+          sb.append(s)
+        }
+        if (sb.isEmpty) "" else sb.substring(0, sb.length() - s.length)
     }
+
+  private val hexAlphabet = Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')
+  private def byteToHexChars(b: Byte, sb: StringBuilder): Unit = {
+    sb.append(hexAlphabet((b >> 4 & 0x0f).toByte.toInt))
+      .append(hexAlphabet((b & 0x0f).toByte.toInt))
+  }
 
   def base642bytes(base64: String): Array[Byte] = Base64.getDecoder.decode(base64)
 

--- a/core/src/main/scala/com/avast/scala/hashes/package.scala
+++ b/core/src/main/scala/com/avast/scala/hashes/package.scala
@@ -44,7 +44,7 @@ package object hashes {
           byteToHexChars(b, sb)
           sb.append(s)
         }
-        if (sb.isEmpty) "" else sb.substring(0, sb.length() - s.length)
+        if (sb.isEmpty) "" else sb.substring(0, sb.length - s.length)
     }
 
   private val hexAlphabet = Array('0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f')

--- a/core/src/test/scala/com/avast/scala/hashes/PackageTest.scala
+++ b/core/src/test/scala/com/avast/scala/hashes/PackageTest.scala
@@ -17,4 +17,33 @@ class PackageTest extends AnyFlatSpec with Matchers {
     }
 
   }
+
+  Seq(
+    ("TRU", 3, None),
+    ("", 1, None),
+    (" TRU", 3, None),
+    (" ", 0, Some(Array.emptyByteArray)),
+    ("001991FF", 3, None),
+    ("001991FF", 5, None),
+    ("001991FF", 4, Some(Array(0, 25, 145, 255).map(_.toByte)))).foreach { case (input, expectedBytes, expectedResult) =>
+    it must s"return expected result from tryHex2bytes for input '$input' string and expecting $expectedBytes bytes" in {
+      tryHex2bytes(input, expectedBytes) match {
+        case Some(value) => value shouldBe expectedResult.get
+        case None => expectedResult shouldBe None
+      }
+    }
+  }
+
+  Seq(
+    ("001991FF", Array(0, 25, 145, 255).map(_.toByte)),
+    (" 001991FF ", Array(0, 25, 145, 255).map(_.toByte)),
+    ("uu001991FFuu", Array(0, 25, 145, 255).map(_.toByte)),
+    ("WFTF", Array(255).map(_.toByte)),
+    ("uuuu", Array.emptyByteArray),
+    ("", Array.emptyByteArray)).foreach { case (input, expectedResult) =>
+    it must s"return expected result from hex2bytes for input '$input' string" in {
+      hex2bytes(input) shouldBe expectedResult
+    }
+  }
+
 }

--- a/core/src/test/scala/com/avast/scala/hashes/PackageTest.scala
+++ b/core/src/test/scala/com/avast/scala/hashes/PackageTest.scala
@@ -1,0 +1,20 @@
+package com.avast.scala.hashes
+
+import org.junit.runner.RunWith
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class PackageTest extends AnyFlatSpec with Matchers {
+
+  Seq((Array(0, 25, 145, 255).map(_.toByte), Some("-"), "00-19-91-ff"),
+      (Array.emptyByteArray, Some("-"), ""),
+      (Array(0, 25, 145, 255).map(_.toByte), None, "001991ff")).foreach { case (bytes: Array[Byte], separator, expected) =>
+
+    it must s"convert ${bytes.mkString("Array(", ", ", ")")} separated with $separator to $expected" in {
+      bytes2hex(bytes, separator) shouldBe expected
+    }
+
+  }
+}


### PR DESCRIPTION
We are dealing with higher CPU usage in some of our applications and performance monitoring (using Flight Recorder) showed that the issue could be in `Sha256` decoding, which is used extensively in the applications.

Even the stacktrace from parsing is pretty deep:
![image](https://user-images.githubusercontent.com/273052/125648906-9c6ab5b5-a6b2-44a0-a1e6-37618d6ab7e2.png)

So I decided to rewrite the critical parts from _Scalish_ code to _hardcode_ optimized code (but still readable). The implementation is inspired by [code](https://github.com/scodec/scodec-bits/blob/main/core/shared/src/main/scala/scodec/bits/ByteVector.scala) [from scodec](https://github.com/scodec/scodec-bits/blob/main/core/shared/src/main/scala/scodec/bits/Bases.scala). I prefer to keep this library dependencies-less, so not to add the scodec as a dependency of this project.

Please note that `while` must be used because [optimized for-cycle for basic usages is still not a solved thing](https://github.com/scala/bug/issues/1338).